### PR TITLE
Add compatibility with ESP32 GPIO RGB LEDs

### DIFF
--- a/adafruit_rgbled.py
+++ b/adafruit_rgbled.py
@@ -59,7 +59,7 @@ class RGBLED:
     :type ~microcontroller.Pin: Microcontroller's blue_pin.
     :type pulseio.PWMOut: PWMOut object associated with blue_pin.
     :type PWMChannel: PCA9685 PWM channel associated with blue_pin.
-    :param ESP_SPIcontrol esp: The ESP object connected to a RGB LED.
+    :param ESP_SPIcontrol esp: The ESP object connected to a RGB LED. Defaults to None.
     :param bool invert_pwm: False if the RGB LED is common cathode,
         true if the RGB LED is common anode.
 
@@ -141,8 +141,7 @@ class RGBLED:
                 esp.set_pin_mode(self._rgb_led_pins[i], 1)
             else:
                 raise TypeError('Must provide a pin, PWMOut, ESP Object, or PWMChannel.')
-        if esp is not None:
-            self._esp = esp
+        self._esp = esp
         self._invert_pwm = invert_pwm
         self._current_color = (0, 0, 0)
         self.color = self._current_color
@@ -196,8 +195,8 @@ class RGBLED:
         :param int color: Color, from color method.
         :param int rgb_led_pin: GPIO pin to write to.
         """
-        if self._esp:
+        if self._esp is not None:
             color = map_range(abs(color), 0, 65535, 0, 1.0)
             self._esp.set_analog_write(rgb_led_pin, abs(color))
         else:
-            rgb_led_pin.duty_cycle(abs(color))
+            rgb_led_pin.duty_cycle = abs(color)

--- a/examples/rgbled_esp32spi.py
+++ b/examples/rgbled_esp32spi.py
@@ -1,0 +1,67 @@
+import time
+import board
+import busio
+from digitalio import DigitalInOut
+import adafruit_rgbled
+from adafruit_esp32spi import adafruit_esp32spi
+
+# If you have an externally connected ESP32:
+esp32_cs = DigitalInOut(board.D13)
+esp32_ready = DigitalInOut(board.D11)
+esp32_reset = DigitalInOut(board.D12)
+
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+
+RED_LED = 26
+GREEN_LED = 25
+BLUE_LED = 27
+
+# Create the RGB LED Object
+led = adafruit_rgbled.RGBLED(RED_LED, GREEN_LED, BLUE_LED, esp)
+
+def wheel(pos):
+    # Input a value 0 to 255 to get a color value.
+    # The colours are a transition r - g - b - back to r.
+    if pos < 0 or pos > 255:
+        return 0, 0, 0
+    if pos < 85:
+        return int(255 - pos * 3), int(pos * 3), 0
+    if pos < 170:
+        pos -= 85
+        return 0, int(255 - pos * 3), int(pos * 3)
+    pos -= 170
+    return int(pos * 3), 0, int(255 - (pos * 3))
+
+def rainbow_cycle(wait):
+    for i in range(255):
+        i = (i + 1) % 256
+        led.color = wheel(i)
+        time.sleep(wait)
+
+while True:
+    # setting RGB LED color to RGB Tuples (R, G, B)
+    print('setting color 1')
+    led.color = (255, 0, 0)
+    time.sleep(1)
+
+    print('setting color 2')
+    led.color = (0, 255, 0)
+    time.sleep(1)
+
+    print('setting color 3')
+    led.color = (0, 0, 255)
+    time.sleep(1)
+
+    # setting RGB LED color to 24-bit integer values
+    led.color = 0xFF0000
+    time.sleep(1)
+
+    led.color = 0x00FF00
+    time.sleep(1)
+
+    led.color = 0x0000FF
+    time.sleep(1)
+
+    # rainbow cycle the RGB LED
+    rainbow_cycle(0.1)


### PR DESCRIPTION
**This pull request adds:**
- RGBLED support for using an `ESP_SPIControl` object, `esp`,  provided three RGB LED pins.
- `color` setter method no longer handles PWM, only color conversion and integer scaling. 
  - `_write_color` method added to support multiple types of PWMOut methods and simplify `color()` setter.
- Usage example for  ESP32-connected RGBLEDs 

_Usage Example_
```
import board
import adafruit_rgbled
from adafruit_esp32spi import adafruit_esp32spi

# Create ESP Object
esp32_cs = DigitalInOut(board.D13)
esp32_ready = DigitalInOut(board.D11)
esp32_reset = DigitalInOut(board.D12)
spi = busio.SPI(board.SCK, board.MOSI, board.MISO)

esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)

with adafruit_rgbled.RGBLED(25, 26, 27, esp) as rgb_led:
    rgb_led.color = (0, 255, 0)
```

**This pull request has been tested with**: a pin-based RGB LED, PCA9685 (PWMOut object), and a RGB LED connected to an ESP32 (AirLift FeatherWing)