### PR TITLE
Error check colors

### DIFF
--- a/adafruit_rgbled.py
+++ b/adafruit_rgbled.py
@@ -98,9 +98,9 @@ class RGBLED:
 
     def __init__(
         self,
-        red_pin: Union["microcontroller.Pin", PWMOut, "PWMChannel"],
-        green_pin: Union["microcontroller.Pin", PWMOut, "PWMChannel"],
-        blue_pin: Union["microcontroller.Pin", PWMOut, "PWMChannel"],
+        red_pin: Union[Pin, PWMOut, "PWMChannel"],
+        green_pin: Union[Pin, PWMOut, "PWMChannel"],
+        blue_pin: Union[Pin, PWMOut, "PWMChannel"],
         invert_pwm: bool = False,
     ) -> None:
         self._rgb_led_pins = [red_pin, green_pin, blue_pin]

--- a/adafruit_rgbled.py
+++ b/adafruit_rgbled.py
@@ -143,12 +143,13 @@ class RGBLED:
     def color(self, value: Union[int, tuple]):
         if isinstance(value, int):
             try:
+                # Check that integer is <= 0xffffff and create an iterable.
                 rgb = value.to_bytes(3, "big", signed=False)
             except OverflowError as exc:
                 raise ValueError("Only bits 0->23 valid for integer input") from exc
         elif isinstance(value, tuple):
             try:
-                rgb = bytes(value)
+                rgb = bytes(value)  # Check that tuple has 3 integers of 0 - 255.
                 if len(rgb) != 3:
                     raise ValueError
             except (ValueError, TypeError) as exc:
@@ -160,6 +161,7 @@ class RGBLED:
                 "Color must be a tuple of 3 integers or 24-bit integer value."
             )
         for color, intensity in enumerate(rgb):
+            # Take advantage of bool truthiness.
             self._rgb_led_pins[color].duty_cycle = abs(
                 intensity * 257 - 65535 * self._invert_pwm
             )

--- a/adafruit_rgbled.py
+++ b/adafruit_rgbled.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+# pylint: disable=raise-missing-from
 """
 `adafruit_rgbled`
 ================================================================================
@@ -106,12 +107,11 @@ class RGBLED:
                 if pin_type.startswith("<class '") and pin_type.endswith("Pin'>"):
                     self._rgb_led_pins[pin] = PWMOut(self._rgb_led_pins[pin])
                 self._rgb_led_pins[pin].duty_cycle = 0
-            except AttributeError as exc:
-                raise TypeError(
-                    "Pins must be of type Pin, PWMOut or PWMChannel"
-                ) from exc
+            except AttributeError:
+                raise TypeError("Pins must be of type Pin, PWMOut or PWMChannel")
         self._invert_pwm = invert_pwm
         self._current_color = (0, 0, 0)
+        self.color = self._current_color
 
     def __enter__(self) -> "RGBLED":
         return self
@@ -144,17 +144,17 @@ class RGBLED:
             try:
                 # Check that integer is <= 0xffffff and create an iterable.
                 rgb = value.to_bytes(3, "big", signed=False)
-            except OverflowError as exc:
-                raise ValueError("Only bits 0->23 valid for integer input") from exc
+            except OverflowError:
+                raise ValueError("Only bits 0->23 valid for integer input")
         elif isinstance(value, tuple):
             try:
                 rgb = bytes(value)  # Check that tuple has integers of 0 - 255.
                 if len(rgb) != 3:
                     raise ValueError
-            except (ValueError, TypeError) as exc:
+            except (ValueError, TypeError):
                 raise ValueError(
                     "Only a tuple of 3 integers of 0 - 255 for tuple input."
-                ) from exc
+                )
         else:
             raise TypeError(
                 "Color must be a tuple of 3 integers or 24-bit integer value."

--- a/adafruit_rgbled.py
+++ b/adafruit_rgbled.py
@@ -81,6 +81,15 @@ class RGBLED:
         import adafruit_rgbled
         with adafruit_rgbled.RGBLED(board.D5, board.D6, board.D7, invert_pwm=True) as rgb_led:
             rgb_led.color = (0, 255, 0)
+
+    :param Union["microcontroller.Pin", PWMOut, "PWMChannel"] red_pin:
+        The connection to the red LED.
+    :param Union["microcontroller.Pin", PWMOut, "PWMChannel"] green_pin:
+        The connection to the green LED.
+    :param Union["microcontroller.Pin", PWMOut, "PWMChannel"] blue_pin:
+        The connection to the blue LED.
+    :param bool invert_pwm: False if the RGB LED is common cathode,
+        True if the RGB LED is common anode. Defaults to False.
     """
 
     def __init__(
@@ -90,16 +99,6 @@ class RGBLED:
         blue_pin: Union["microcontroller.Pin", PWMOut, "PWMChannel"],
         invert_pwm: bool = False,
     ) -> None:
-        """
-        :param Union["microcontroller.Pin", PWMOut, "PWMChannel"] red_pin:
-        The connection to the red LED.
-        :param Union["microcontroller.Pin", PWMOut, "PWMChannel"] green_pin:
-        The connection to the green LED.
-        :param Union["microcontroller.Pin", PWMOut, "PWMChannel"] blue_pin:
-        The connection to the blue LED.
-        :param bool invert_pwm: False if the RGB LED is common cathode,
-        True if the RGB LED is common anode. Defaults to False.
-        """
         self._rgb_led_pins = [red_pin, green_pin, blue_pin]
         for pin, _ in enumerate(self._rgb_led_pins):
             try:

--- a/adafruit_rgbled.py
+++ b/adafruit_rgbled.py
@@ -100,18 +100,18 @@ class RGBLED:
         True if the RGB LED is common anode. Defaults to False.
         """
         self._rgb_led_pins = [red_pin, green_pin, blue_pin]
-        for pin in self._rgb_led_pins:
+        for pin, _ in enumerate(self._rgb_led_pins):
             try:
-                if str(type(pin)) == "<class 'Pin'>":
-                    pin = PWMOut(pin)
-                pin.duty_cycle = 0
+                pin_type = str(type(self._rgb_led_pins[pin]))
+                if pin_type.startswith("<class '") and pin_type.endswith("Pin'>"):
+                    self._rgb_led_pins[pin] = PWMOut(self._rgb_led_pins[pin])
+                self._rgb_led_pins[pin].duty_cycle = 0
             except AttributeError as exc:
                 raise TypeError(
                     "Pins must be of type Pin, PWMOut or PWMChannel"
                 ) from exc
         self._invert_pwm = invert_pwm
         self._current_color = (0, 0, 0)
-        self.color = self._current_color
 
     def __enter__(self) -> "RGBLED":
         return self

--- a/adafruit_rgbled.py
+++ b/adafruit_rgbled.py
@@ -136,8 +136,8 @@ class RGBLED:
         :param Union[int, tuple] value: RGB LED desired value - can be a RGB tuple of values
         0 - 255 or a 24-bit integer. e.g. (255, 64, 35) and 0xff4023 are equivalent.
 
-        :raises ValueError: If the input is an int > 0xffffff or is not a tuple of 3 integers
-            0 - 255.
+        :raises ValueError: If the input is an int > 0xffffff or is a tuple that does not
+          contain 3 integers of 0 - 255.
         :raises TypeError: If the input is not an integer or a tuple.
         """
         return self._current_color

--- a/adafruit_rgbled.py
+++ b/adafruit_rgbled.py
@@ -136,7 +136,8 @@ class RGBLED:
         :param Union[int, tuple] value: RGB LED desired value - can be a RGB tuple of values
         0 - 255 or a 24-bit integer. e.g. (255, 64, 35) and 0xff4023 are equivalent.
 
-        :raises ValueError: If the input is an int > 0xffffff.
+        :raises ValueError: If the input is an int > 0xffffff or is not a tuple of 3 integers
+            0 - 255.
         :raises TypeError: If the input is not an integer or a tuple.
         """
         return self._current_color
@@ -167,5 +168,5 @@ class RGBLED:
                 )
         except IndexError as exc:
             self.color = old_color
-            raise ValueError("Tuple must be 3 integers.") from exc
+            raise ValueError("Tuple must contain 3 integers.") from exc
         self._current_color = value

--- a/adafruit_rgbled.py
+++ b/adafruit_rgbled.py
@@ -100,16 +100,15 @@ class RGBLED:
         True if the RGB LED is common anode. Defaults to False.
         """
         self._rgb_led_pins = [red_pin, green_pin, blue_pin]
-        for i in range(  # pylint: disable=consider-using-enumerate
-            len(self._rgb_led_pins)
-        ):
-            if hasattr(self._rgb_led_pins[i], "frequency"):
-                self._rgb_led_pins[i].duty_cycle = 0
-            elif str(type(self._rgb_led_pins[i])) == "<class 'Pin'>":
-                self._rgb_led_pins[i] = PWMOut(self._rgb_led_pins[i])
-                self._rgb_led_pins[i].duty_cycle = 0
-            else:
-                raise TypeError("Must provide a pin, PWMOut, or PWMChannel.")
+        for pin in self._rgb_led_pins:
+            try:
+                if str(type(pin)) == "<class 'Pin'>":
+                    pin = PWMOut(pin)
+                pin.duty_cycle = 0
+            except AttributeError as exc:
+                raise TypeError(
+                    "Pins must be of type Pin, PWMOut or PWMChannel"
+                ) from exc
         self._invert_pwm = invert_pwm
         self._current_color = (0, 0, 0)
         self.color = self._current_color
@@ -149,7 +148,7 @@ class RGBLED:
                 raise ValueError("Only bits 0->23 valid for integer input") from exc
         elif isinstance(value, tuple):
             try:
-                rgb = bytes(value)  # Check that tuple has 3 integers of 0 - 255.
+                rgb = bytes(value)  # Check that tuple has integers of 0 - 255.
                 if len(rgb) != 3:
                     raise ValueError
             except (ValueError, TypeError) as exc:

--- a/adafruit_rgbled.py
+++ b/adafruit_rgbled.py
@@ -20,9 +20,6 @@ Implementation Notes
 """
 try:
     from typing import Union
-    import adafruit_pca9685 as pca9685
-    import pwmio
-    import microcontroller
 except ImportError:
     pass
 
@@ -87,20 +84,20 @@ class RGBLED:
 
     def __init__(
         self,
-        red_pin: Union[microcontroller.Pin, pwmio.PWMOut, pca9685.PWMChannel],
-        green_pin: Union[microcontroller.Pin, pwmio.PWMOut, pca9685.PWMChannel],
-        blue_pin: Union[microcontroller.Pin, pwmio.PWMOut, pca9685.PWMChannel],
+        red_pin: Union["microcontroller.Pin", PWMOut, "PWMChannel"],
+        green_pin: Union["microcontroller.Pin", PWMOut, "PWMChannel"],
+        blue_pin: Union["microcontroller.Pin", PWMOut, "PWMChannel"],
         invert_pwm: bool = False,
     ) -> None:
         """
-        :param Union[microcontroller.Pin, pwmio.PWMOut, pca9685.PWMChannel] red_pin:
+        :param Union["microcontroller.Pin", PWMOut, "PWMChannel"] red_pin:
         The connection to the red LED.
-        :param Union[microcontroller.Pin, pwmio.PWMOut, pca9685.PWMChannel] green_pin:
+        :param Union["microcontroller.Pin", PWMOut, "PWMChannel"] green_pin:
         The connection to the green LED.
-        :param Union[microcontroller.Pin, pwmio.PWMOut, pca9685.PWMChannel] blue_pin:
+        :param Union["microcontroller.Pin", PWMOut, "PWMChannel"] blue_pin:
         The connection to the blue LED.
         :param bool invert_pwm: False if the RGB LED is common cathode,
-        True if the RGB LED is common anode.
+        True if the RGB LED is common anode. Defaults to False.
         """
         self._rgb_led_pins = [red_pin, green_pin, blue_pin]
         for i in range(  # pylint: disable=consider-using-enumerate

--- a/adafruit_rgbled.py
+++ b/adafruit_rgbled.py
@@ -144,7 +144,6 @@ class RGBLED:
 
     @color.setter
     def color(self, value: Union[int, tuple]):
-        old_color = self._current_color
         if isinstance(value, int):
             try:
                 rgb = value.to_bytes(3, "big", signed=False)
@@ -153,6 +152,8 @@ class RGBLED:
         elif isinstance(value, tuple):
             try:
                 rgb = bytes(value)
+                if len(rgb) != 3:
+                    raise ValueError
             except (ValueError, TypeError) as exc:
                 raise ValueError(
                     "Only a tuple of 3 integers of 0 - 255 for tuple input."
@@ -161,12 +162,8 @@ class RGBLED:
             raise TypeError(
                 "Color must be a tuple of 3 integers or 24-bit integer value."
             )
-        try:
-            for color, intensity in enumerate(rgb):
-                self._rgb_led_pins[color].duty_cycle = abs(
-                    intensity * 257 - 65535 * self._invert_pwm
-                )
-        except IndexError as exc:
-            self.color = old_color
-            raise ValueError("Tuple must contain 3 integers.") from exc
+        for color, intensity in enumerate(rgb):
+            self._rgb_led_pins[color].duty_cycle = abs(
+                intensity * 257 - 65535 * self._invert_pwm
+            )
         self._current_color = value


### PR DESCRIPTION
closes #19, #24. Adds error checking for `RGBLED.color`. Detects pins on Raspberry Pi 4.

Tested on CP 8.0.4 with Pico and an RGB LED, also with Python 3.9.X and Blinka on Raspberry Pi 4.

Pins correctly detected on Raspi.

Various invalid inputs rejected and valid inputs accepted on Pico.